### PR TITLE
51 feature get script samples from cli repo

### DIFF
--- a/data/samples.json
+++ b/data/samples.json
@@ -6,8 +6,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/aad-analyze-users-hibp/README.md",
       "description": "Validate all your users against known breaches with the have i been pwned api. That way you can quickly scan if your users are part of any known breaches",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/aad-analyze-users-hibp/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Albert-Jan Schot",
@@ -24,7 +28,9 @@
         "m365 status",
         "m365 aad user hibp",
         "m365 aad user list"
-      ]
+      ],
+      "createDate": "2022-01-21",
+      "source": "script-samples"
     },
     {
       "title": "Get Azure AD app permission info (delegated or application)",
@@ -32,8 +38,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/aad-get-app-permission/README.md",
       "description": "Get any existing delegated or application permission info associated to a Microsoft AAD app from its name",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/aad-get-app-permission/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Michaël Maillot",
@@ -49,7 +59,9 @@
         "m365 cli config set",
         "Connect-MgGraph",
         "Get-MgServicePrincipal"
-      ]
+      ],
+      "createDate": "2022-08-10",
+      "source": "script-samples"
     },
     {
       "title": "Inventory Guest Sign-In Activity with CLI for M365 and Microsoft Graph",
@@ -57,15 +69,21 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/aad-guest-signin-activity/README.md",
       "description": "Inventories Guest accounts from Azure Active Directory to query all Guest accounts and signInActivity and saves report to SharePoint List",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/aad-guest-signin-activity/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Pete Skelly",
           "pictureUrl": "https://avatars.githubusercontent.com/u/5527235?v=4"
         }
       ],
-      "tags": []
+      "tags": [],
+      "createDate": "2021-12-21",
+      "source": "script-samples"
     },
     {
       "title": "Undelete items from SharePoint Recycle bin",
@@ -73,8 +91,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/bulk-undelete-from-recyclebin/README.md",
       "description": "This script allows users to undelete items from recycle bin and restore it in respective document library and list.",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/bulk-undelete-from-recyclebin/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Adam Wójcik",
@@ -95,7 +117,9 @@
         "m365 status",
         "m365 spo site recyclebinitem list",
         "m365 spo site recyclebinitem restore"
-      ]
+      ],
+      "createDate": "2021-06-25",
+      "source": "script-samples"
     },
     {
       "title": "Create Modern Sites as alternative primary language",
@@ -103,8 +127,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/create-comm-sites-specific-locale/README.md",
       "description": "Create a modern site in another language as the primary language",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/create-comm-sites-specific-locale/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Adam Wójcik",
@@ -115,7 +143,9 @@
           "pictureUrl": "https://avatars.githubusercontent.com/u/8781041?v=4"
         }
       ],
-      "tags": null
+      "tags": null,
+      "createDate": "2021-05-11",
+      "source": "script-samples"
     },
     {
       "title": "Create bulk dummy documents inc versions in SharePoint Document library",
@@ -123,8 +153,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/create-dummy-docs-versions-in-library/README.md",
       "description": "This script sample can be useful to upload dummy documents and versions to SP library by auto incrementing file name",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/create-dummy-docs-versions-in-library/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Mathijs Verbeeck",
@@ -135,7 +169,9 @@
           "pictureUrl": "https://avatars.githubusercontent.com/u/20593570?s=400&u=f9a4d5137685d8c3fcc60394fc193f3e8156f678&v=4"
         }
       ],
-      "tags": []
+      "tags": [],
+      "createDate": "2022-01-02",
+      "source": "script-samples"
     },
     {
       "title": "Fetch User Profile Properties From Site Collection And Export To CSV",
@@ -143,8 +179,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/fetch-user-profile-properties/README.md",
       "description": "Get users or user profile properties from any SharePoint site collection and we need it in CSV or Excel format",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/fetch-user-profile-properties/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Mathijs Verbeeck",
@@ -155,7 +195,9 @@
           "pictureUrl": "https://avatars.githubusercontent.com/u/52065929?v=4"
         }
       ],
-      "tags": null
+      "tags": null,
+      "createDate": "2021-03-24",
+      "source": "script-samples"
     },
     {
       "title": "Flow run status list dashboard",
@@ -163,15 +205,21 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/flow-runs-status-list-dashboard/README.md",
       "description": "Powershell script that reports the status of the latest run of all flows by writing to a M365 list",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/flow-runs-status-list-dashboard/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Ryan Healy",
           "pictureUrl": "https://github.com/Ryan365Apps.png"
         }
       ],
-      "tags": []
+      "tags": [],
+      "createDate": "2022-02-01",
+      "source": "script-samples"
     },
     {
       "title": " Generate Markdown Report of LCIDs",
@@ -179,8 +227,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/generate-markdown-lcids/README.md",
       "description": "Simple report listing out the language IDs in Markdown",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/generate-markdown-lcids/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Adam Wójcik",
@@ -191,7 +243,9 @@
           "pictureUrl": "https://avatars.githubusercontent.com/u/8781041?v=4"
         }
       ],
-      "tags": null
+      "tags": null,
+      "createDate": "2021-05-11",
+      "source": "script-samples"
     },
     {
       "title": "How to to get all site collections with their sub webs",
@@ -199,8 +253,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/get-all-site-collections-subwebs/README.md",
       "description": "Get site collections with all the sub-webs",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/get-all-site-collections-subwebs/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Adam Wójcik",
@@ -221,7 +279,9 @@
         "Get-PnPSubWeb",
         "Get-PnPTenant",
         "Get-PnPTenantSite"
-      ]
+      ],
+      "createDate": "2021-05-05",
+      "source": "script-samples"
     },
     {
       "title": "Authenticate with and call the Microsoft Graph",
@@ -229,8 +289,14 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/graph-call-graph/README.md",
       "description": "Obtain a new access token for the Microsoft Graph and use it an HTTP request, or connect to the Graph",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/graph-call-graph/assets/preview.png",
-      "type": "bash",
-      "tabTag": "#tab/cli-m365-bash",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps",
+        "#tab/cli-m365-bash"
+      ],
       "authors": [
         {
           "name": "Garry Trinder",
@@ -252,7 +318,9 @@
         "Get-MgContext",
         "Get-MgUser",
         "Disconnect-MgGraph"
-      ]
+      ],
+      "createDate": "2021-08-23",
+      "source": "script-samples"
     },
     {
       "title": "Get Started with Tooltip for Connected Account",
@@ -260,8 +328,8 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/magic-tooltips-module/README.md",
       "description": "The Magic Tooltips module can be installed to help determine the account that is connected to Microsoft 365 or Azure.",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/magic-tooltips-module/assets/preview.png",
-      "type": "",
-      "tabTag": "",
+      "type": [],
+      "tabTag": [],
       "authors": [
         {
           "name": "Paul Schaeflein",
@@ -271,7 +339,9 @@
       "tags": [
         "magic tooltips",
         "magic"
-      ]
+      ],
+      "createDate": "2021-06-21",
+      "source": "script-samples"
     },
     {
       "title": "Copy Planner plan",
@@ -279,8 +349,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/planner-copy-planner-plan/README.md",
       "description": "With this sample, you can copy an existing plan to a certain group.",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/planner-copy-planner-plan/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Reshmee Auckloo",
@@ -310,7 +384,9 @@
         "Get-PnPPlannerPlan",
         "Get-PnPPlannerTask",
         "New-PnPPlannerPlan"
-      ]
+      ],
+      "createDate": "2022-06-05",
+      "source": "script-samples"
     },
     {
       "title": "Planner migration to SharePoint list",
@@ -318,8 +394,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/planner-migration-spo-list/README.md",
       "description": "Migrate a planner plan with buckets and tasks to a SharePoint Online list",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/planner-migration-spo-list/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Jasey Waegebaert",
@@ -367,7 +447,9 @@
         "Set-PnPList",
         "Set-PnPListItem",
         "Set-PnPView"
-      ]
+      ],
+      "createDate": "2022-05-23",
+      "source": "script-samples"
     },
     {
       "title": "Remove delete option on a document library",
@@ -375,8 +457,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/remove-delete-option-library/README.md",
       "description": "Remove the delete option on a document library to prevent users from accidentally deleting libraries",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/remove-delete-option-library/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Adam Wójcik",
@@ -387,7 +473,9 @@
           "pictureUrl": "https://avatars.githubusercontent.com/u/8781041?v=4"
         }
       ],
-      "tags": null
+      "tags": null,
+      "createDate": "2018-09-17",
+      "source": "script-samples"
     },
     {
       "title": "Report of Private Teams channels to Excel",
@@ -395,8 +483,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/report-private-teams-excel/README.md",
       "description": "Gathers all of the teams private channels in your tenant and produces an Excel file",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/report-private-teams-excel/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Adam Wójcik",
@@ -407,7 +499,9 @@
           "pictureUrl": "https://avatars.githubusercontent.com/u/8781041?v=4"
         }
       ],
-      "tags": null
+      "tags": null,
+      "createDate": "2021-02-27",
+      "source": "script-samples"
     },
     {
       "title": "Reset files permission unique to inheritance",
@@ -415,8 +509,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/reset-files-permission-unique-to-inherited/README.md",
       "description": "Reset bulk file permissions  from unique to parent folder inheritance.",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/reset-files-permission-unique-to-inherited/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Nanddeep Nachan",
@@ -445,7 +543,9 @@
         "m365 spo file get",
         "m365 spo listitem get",
         "m365 spo listitem roleinheritance reset"
-      ]
+      ],
+      "createDate": "2021-08-11",
+      "source": "script-samples"
     },
     {
       "title": "Add a document library web part to a page",
@@ -453,8 +553,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-add-document-library-webpart-to-page/README.md",
       "description": "Add a document library web part to a page (and only show a specific folder)",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-add-document-library-webpart-to-page/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Todd Klindt",
@@ -469,7 +573,9 @@
           "pictureUrl": "https://avatars.githubusercontent.com/u/47852415?v=4"
         }
       ],
-      "tags": []
+      "tags": [],
+      "createDate": "2021-06-18",
+      "source": "script-samples"
     },
     {
       "title": "Add multiple lists or libraries using csv file",
@@ -477,15 +583,21 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-add-multiple-lists-using-csv-file/README.md",
       "description": "This script sample shows how to bulk create lists or libraries using CSV file",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-add-multiple-lists-using-csv-file/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Valeras Narbutas",
           "pictureUrl": "https://avatars.githubusercontent.com/u/16476453?s=400&v=4"
         }
       ],
-      "tags": []
+      "tags": [],
+      "createDate": "2021-10-08",
+      "source": "script-samples"
     },
     {
       "title": "Creates and apply custom site design with custom column types",
@@ -493,8 +605,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-add-site-design-with-custom-list/README.md",
       "description": "Script that creates and applies custom site design with custom column types",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-add-site-design-with-custom-list/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Valeras Narbutas",
@@ -518,7 +634,9 @@
         "Invoke-PnPSiteDesign",
         "Set-PnPSite",
         "Set-PnPSiteDesign"
-      ]
+      ],
+      "createDate": "2021-10-03",
+      "source": "script-samples"
     },
     {
       "title": "Add a tenant theme to SharePoint Online",
@@ -526,8 +644,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-add-tenant-theme/README.md",
       "description": "This is example for adding a SharePoint Theme as an option for modern sites in the tenant",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-add-tenant-theme/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Chandani Prajapati",
@@ -542,7 +664,9 @@
           "pictureUrl": "https://avatars.githubusercontent.com/u/8781041?v=4"
         }
       ],
-      "tags": []
+      "tags": [],
+      "createDate": "2021-10-02",
+      "source": "script-samples"
     },
     {
       "title": "Script allow copy column format in SharePoint and apply to different column.",
@@ -550,8 +674,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-apply-column-format/README.md",
       "description": "Copy column format from column or web sample and apply to different column",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-apply-column-format/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Jasey Waegebaert",
@@ -571,7 +699,9 @@
         "m365 status",
         "m365 spo field get",
         "m365 spo field set"
-      ]
+      ],
+      "createDate": "2021-09-29",
+      "source": "script-samples"
     },
     {
       "title": "Clean Up Unwanted Site Columns from Content Types and Lists/Libraries",
@@ -579,8 +709,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-cleanup-site-column-usage/README.md",
       "description": "We decide we want to trim away a few of the Site Columns we’ve created, here is the script that does just that",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-cleanup-site-column-usage/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Adam Wójcik",
@@ -591,7 +725,9 @@
           "pictureUrl": "https://avatars.githubusercontent.com/u/1295627?v=4"
         }
       ],
-      "tags": []
+      "tags": [],
+      "createDate": "2021-10-15",
+      "source": "script-samples"
     },
     {
       "title": "Copy library view to another library(ies)",
@@ -599,8 +735,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-copy-library-view/README.md",
       "description": "The script copies a library view to library(ies) in destination site",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-copy-library-view/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Reshmee Auckloo",
@@ -622,7 +762,9 @@
         "m365 spo list view add",
         "m365 spo list view get",
         "m365 spo list view set"
-      ]
+      ],
+      "createDate": "2021-10-08",
+      "source": "script-samples"
     },
     {
       "title": "Bulk library generation",
@@ -630,8 +772,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-create-bulk-libraries/README.md",
       "description": "With this sample, you can create a whole bunch of libraries at once.",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-create-bulk-libraries/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Milan Holemans",
@@ -654,7 +800,9 @@
         "Add-PnPView",
         "Connect-PnPOnline",
         "New-PnPList"
-      ]
+      ],
+      "createDate": "2022-03-29",
+      "source": "script-samples"
     },
     {
       "title": "Delete orphaned temporary pages from Site Pages",
@@ -662,8 +810,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-delete-orphaned-temporary-sitepages/README.md",
       "description": "Script to clean up temporary pages from Site Pages library",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-delete-orphaned-temporary-sitepages/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Reshmee Auckloo",
@@ -690,7 +842,9 @@
         "m365 spo file checkin",
         "m365 spo file checkout",
         "m365 spo list get"
-      ]
+      ],
+      "createDate": "2022-02-14",
+      "source": "script-samples"
     },
     {
       "title": "Export CSV To SharePoint List Data",
@@ -698,8 +852,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-export-data-to-sharepoint-lists/README.md",
       "description": "This script sample shows how to export CSV to SharePoint list data",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-export-data-to-sharepoint-lists/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Adam Wójcik",
@@ -720,7 +878,9 @@
         "Add-PnPField",
         "Add-PnPListItem",
         "New-PnPList"
-      ]
+      ],
+      "createDate": "2021-07-12",
+      "source": "script-samples"
     },
     {
       "title": "Get Hub Sites Information And Export It To CSV",
@@ -728,8 +888,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-export-hub-sites-details-to-csv/README.md",
       "description": "This script sample shows how to get hub sites information and export it to CSV",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-export-hub-sites-details-to-csv/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Jasey Waegebaert",
@@ -744,7 +908,9 @@
         "SharePoint Online",
         "Connect-PnPOnline",
         "Get-PnPHubSite"
-      ]
+      ],
+      "createDate": "2022-04-20",
+      "source": "script-samples"
     },
     {
       "title": "Export SharePoint List Data to CSV with attachments",
@@ -752,8 +918,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-export-sharepoint-list-items-to-csv/README.md",
       "description": "This script sample shows how to export SharePoint list to CSV with attachments",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-export-sharepoint-list-items-to-csv/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Nanddeep Nachan",
@@ -770,7 +940,9 @@
         "m365 spo listitem list",
         "m365 spo listitem attachment list",
         "m365 spo file get"
-      ]
+      ],
+      "createDate": "2021-09-26",
+      "source": "script-samples"
     },
     {
       "title": "Export SharePoint Term Store terms to CSV",
@@ -778,8 +950,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-export-termstore-terms-to-csv/README.md",
       "description": "Export SharePoint Term Store terms to CSV",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-export-termstore-terms-to-csv/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Reshmee Auckloo",
@@ -803,7 +979,9 @@
         "Get-PnPTerm",
         "Get-PnPTermGroup",
         "Get-PnPTermSet"
-      ]
+      ],
+      "createDate": "2022-07-07",
+      "source": "script-samples"
     },
     {
       "title": "Generate Demo Events for SharePoint Events List",
@@ -811,8 +989,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-generate-demo-events/README.md",
       "description": "This sample script generates demo events for the SharePoint Events List within a modern site using a CSV file",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-generate-demo-events/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Adam Wójcik",
@@ -830,7 +1012,9 @@
         "m365 spo listitem add",
         "Add-PnPListItem",
         "Connect-PnPOnline"
-      ]
+      ],
+      "createDate": "2021-09-08",
+      "source": "script-samples"
     },
     {
       "title": "Get All Apps From The App Catalog And Export It To CSV",
@@ -838,8 +1022,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-get-all-apps-from-appcatalog/README.md",
       "description": "This script sample shows how to get all apps from the app catalog and export it to CSV.",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-get-all-apps-from-appcatalog/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Adam Wójcik",
@@ -850,7 +1038,9 @@
           "pictureUrl": "https://avatars.githubusercontent.com/u/52065929?v=4"
         }
       ],
-      "tags": []
+      "tags": [],
+      "createDate": "2021-12-15",
+      "source": "script-samples"
     },
     {
       "title": "Get SharePoint List Fields With Required properties And Export It To CSV",
@@ -858,8 +1048,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-get-and-export-list-fields/README.md",
       "description": "This script sample shows how to get list fields with some required propertiesand export it to CSV ",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-get-and-export-list-fields/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Nanddeep Nachan",
@@ -877,7 +1071,9 @@
         "m365 spo field list",
         "Connect-PnPOnline",
         "Get-PnPField"
-      ]
+      ],
+      "createDate": "2021-10-13",
+      "source": "script-samples"
     },
     {
       "title": "Get SharePoint List Or Library Permissions And Export It To CSV",
@@ -885,8 +1081,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-get-list-library-permission-export-to-csv/README.md",
       "description": "This script sample shows how to get permission for list/library and export it to CSV with some required details",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-get-list-library-permission-export-to-csv/assets/example.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Nanddeep Nachan",
@@ -908,7 +1108,9 @@
         "Get-PnPGroup",
         "Get-PnPGroupMember",
         "Get-PnPProperty"
-      ]
+      ],
+      "createDate": "2021-10-04",
+      "source": "script-samples"
     },
     {
       "title": "Export all List and Libraries with Item count and Permission in CSV",
@@ -916,8 +1118,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-get-lists-libraries-item-count-permissions/README.md",
       "description": "Get all lists and Libraries along with total Item count and permissions and export it in CSV",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-get-lists-libraries-item-count-permissions/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Adam Wójcik",
@@ -928,7 +1134,9 @@
           "pictureUrl": "https://avatars.githubusercontent.com/u/40450958?v=4"
         }
       ],
-      "tags": []
+      "tags": [],
+      "createDate": "2021-10-08",
+      "source": "script-samples"
     },
     {
       "title": "Get permission group report of a site.",
@@ -936,15 +1144,21 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-group-permission-report/README.md",
       "description": "The scripts get group permission report of site and each list on the site and prints it to console and also sends it as an adaptive card to Teams channel specified by webhook.",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-group-permission-report/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Adam Wójcik",
           "pictureUrl": "https://avatars.githubusercontent.com/u/58668583?v=4"
         }
       ],
-      "tags": []
+      "tags": [],
+      "createDate": "2022-03-06",
+      "source": "script-samples"
     },
     {
       "title": "SharePoint Online Hub Site Association",
@@ -952,8 +1166,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-hub-sites-association/README.md",
       "description": "This script sample shows how to associate SharePoint online site with a hub site.",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-hub-sites-association/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Jasey Waegebaert",
@@ -975,7 +1193,9 @@
         "m365 spo hubsite connect",
         "Add-SPOHubSiteAssociation",
         "Connect-SPOService"
-      ]
+      ],
+      "createDate": "2022-05-14",
+      "source": "script-samples"
     },
     {
       "title": "Install and deploy SPFx solution",
@@ -983,8 +1203,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-install-deploy-spfx-solution/README.md",
       "description": "Install and deploy SPFx solution to the SharePoint site",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-install-deploy-spfx-solution/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Nanddeep Nachan",
@@ -1001,7 +1225,9 @@
         "m365 spo app deploy",
         "m365 spo app get",
         "m365 spo app install"
-      ]
+      ],
+      "createDate": "2022-06-06",
+      "source": "script-samples"
     },
     {
       "title": "Get/add/update/delete list items in large lists",
@@ -1009,8 +1235,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-list-items-large-lists/README.md",
       "description": "Get/add/update/delete items in large SharePoint list",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-list-items-large-lists/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Valeras Narbutas",
@@ -1035,7 +1265,9 @@
         "Remove-PnPListItem",
         "Set-PnPList",
         "Set-PnPListItem"
-      ]
+      ],
+      "createDate": "2021-09-24",
+      "source": "script-samples"
     },
     {
       "title": "Read SharePoint List Items Using CAML Query",
@@ -1043,8 +1275,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-list-items-with-caml-query/README.md",
       "description": "This script sample shows how to get SharePoint list items using CAML query with different types of fields",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-list-items-with-caml-query/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Jago Pauwels",
@@ -1059,7 +1295,9 @@
           "pictureUrl": "https://avatars.githubusercontent.com/u/52065929?v=4"
         }
       ],
-      "tags": []
+      "tags": [],
+      "createDate": "2021-07-19",
+      "source": "script-samples"
     },
     {
       "title": "List external users across all sites and in what site groups they are",
@@ -1067,8 +1305,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-list-site-externalusers-in-groups/README.md",
       "description": "The script shows in what site groups external users are added in all SharePoint Online sites",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-list-site-externalusers-in-groups/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Martin Lingstuyl",
@@ -1090,7 +1332,9 @@
         "Connect-PnPOnline",
         "Get-PnPTenantSite",
         "Invoke-PnPSPRestMethod"
-      ]
+      ],
+      "createDate": "2022-07-08",
+      "source": "script-samples"
     },
     {
       "title": "SharePoint Modern Page Publishing Report",
@@ -1098,8 +1342,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-modern-page-publishing-report/README.md",
       "description": "Scan through modern pages within a site and reports out the publishing status of the pages",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-modern-page-publishing-report/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Nanddeep Nachan",
@@ -1119,7 +1367,9 @@
         "Get-PnPList",
         "Get-PnPListItem",
         "Get-PnPWeb"
-      ]
+      ],
+      "createDate": "2021-11-10",
+      "source": "script-samples"
     },
     {
       "title": "Get SharePoint Site Recycle Bin Items And Export It To CSV",
@@ -1127,8 +1377,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-recyclebin-items-to-csv/README.md",
       "description": "This script sample shows how to get recycle bin items from SharePoint site and export it to CSV",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-recyclebin-items-to-csv/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Adam Wójcik",
@@ -1139,7 +1393,9 @@
           "pictureUrl": "https://avatars.githubusercontent.com/u/52065929?v=4"
         }
       ],
-      "tags": []
+      "tags": [],
+      "createDate": "2021-07-13",
+      "source": "script-samples"
     },
     {
       "title": "Delete custom color themes from SharePoint",
@@ -1147,8 +1403,8 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-remove-custom-themes/README.md",
       "description": "Creating a lot of beautiful themes lately and testing them but don’t want to keep them anymore, this script is for you",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-remove-custom-themes/assets/preview.png",
-      "type": "",
-      "tabTag": "",
+      "type": [],
+      "tabTag": [],
       "authors": [
         {
           "name": "Leon Armston",
@@ -1158,7 +1414,9 @@
       "tags": [
         "SharePoint Online",
         "Themes"
-      ]
+      ],
+      "createDate": "2020-08-23",
+      "source": "script-samples"
     },
     {
       "title": "Delete a library exceeding the list threshold limit. ",
@@ -1166,8 +1424,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-remove-large-library/README.md",
       "description": "Delete a large SharePoint library by removing the files and folders before deleting the library",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-remove-large-library/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Adam Wójcik",
@@ -1178,7 +1440,9 @@
           "pictureUrl": "https://avatars.githubusercontent.com/u/7693852?v=4"
         }
       ],
-      "tags": []
+      "tags": [],
+      "createDate": "2021-12-29",
+      "source": "script-samples"
     },
     {
       "title": "Run A Search Query And Export To CSV",
@@ -1186,8 +1450,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-search-export-to-csv/README.md",
       "description": "Perform a search query (such as 'Show me all News Posts in this tenant') and export the results to CSV.",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-search-export-to-csv/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Smita Nachan",
@@ -1204,7 +1472,9 @@
         "m365 login",
         "m365 spo search",
         "m365 status"
-      ]
+      ],
+      "createDate": "2021-11-03",
+      "source": "script-samples"
     },
     {
       "title": "Set Home site for SharePoint online tenant",
@@ -1212,8 +1482,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-set-home-site/README.md",
       "description": "This sample script sets a communication site as a home site for SharePoint online tenant",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-set-home-site/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Smita Nachan",
@@ -1231,7 +1505,9 @@
         "m365 spo homesite set",
         "Connect-PnPOnline",
         "Set-PnPHomeSite"
-      ]
+      ],
+      "createDate": "2022-01-18",
+      "source": "script-samples"
     },
     {
       "title": "Update user profile properties",
@@ -1239,8 +1515,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-update-user-profile-properties/README.md",
       "description": "This script sample shows how to update user profile properties.",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/spo-update-user-profile-properties/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Jasey Waegebaert",
@@ -1254,7 +1534,9 @@
       "tags": [
         "Connect-PnPOnline",
         "Set-PnPUserProfileProperty"
-      ]
+      ],
+      "createDate": "2022-03-24",
+      "source": "script-samples"
     },
     {
       "title": "Bulk Create Teams with JSON File",
@@ -1262,8 +1544,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/teams-bulk-create-teams/README.md",
       "description": "Create teams in an environment to test governance scenarios making over a 1000 teams - this sample script can generate the required teams.",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/teams-bulk-create-teams/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Nanddeep Nachan",
@@ -1280,7 +1566,9 @@
         "m365 aad o365group add",
         "m365 aad o365group list",
         "m365 aad o365group teamify"
-      ]
+      ],
+      "createDate": "2021-06-24",
+      "source": "script-samples"
     },
     {
       "title": "List all teams and teams members in Microsoft Teams in the tenant",
@@ -1288,8 +1576,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/teams-export-teams-information/README.md",
       "description": "List all teams and teams members in Microsoft Teams in the tenant and exports the results in a CSV",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/teams-export-teams-information/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Chandani Prajapati",
@@ -1307,7 +1599,9 @@
         "Connect-PnPOnline",
         "Get-PnPTeamsTeam",
         "Get-PnPTeamsUser"
-      ]
+      ],
+      "createDate": "2022-02-22",
+      "source": "script-samples"
     },
     {
       "title": "Teams Full Report",
@@ -1315,8 +1609,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/teams-full-report/README.md",
       "description": "Script to generate Team's full report, gathering all Teams,Channels,Tabs available info.",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/teams-full-report/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Reshmee Auckloo",
@@ -1327,7 +1625,9 @@
           "pictureUrl": "https://avatars.githubusercontent.com/u/7837053?v=4"
         }
       ],
-      "tags": []
+      "tags": [],
+      "createDate": "2021-11-02",
+      "source": "script-samples"
     },
     {
       "title": "List guests within Teams in a tenant",
@@ -1335,8 +1635,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/teams-list-guestusers/README.md",
       "description": "List all guests in Microsoft Teams teams in the tenant and exports the results in a CSV.",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/teams-list-guestusers/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Jasey Waegebaert",
@@ -1351,7 +1655,9 @@
           "pictureUrl": "https://avatars.githubusercontent.com/u/7124132?v=4"
         }
       ],
-      "tags": []
+      "tags": [],
+      "createDate": "2021-12-24",
+      "source": "script-samples"
     },
     {
       "title": "Get notified in Microsoft Teams about SharePoint health incidents",
@@ -1359,8 +1665,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/tenant-health-notify-teams/README.md",
       "description": "This script monitors your SharePoint health status and sends a notifications to a Microsoft Teams channel.",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/tenant-health-notify-teams/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Martin Lingstuyl",
@@ -1381,7 +1691,9 @@
         "m365 spo listitem add",
         "m365 spo listitem remove",
         "m365 tenant serviceannouncement healthissue list"
-      ]
+      ],
+      "createDate": "2022-08-25",
+      "source": "script-samples"
     },
     {
       "title": "Testing user preferred language of SharePoint site",
@@ -1389,8 +1701,12 @@
       "rawUrl": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/user-language-for-site/README.md",
       "description": "Changes the MUI setting for a user within the User Information List",
       "image": "https://raw.githubusercontent.com/pnp/script-samples/main/scripts/user-language-for-site/assets/preview.png",
-      "type": "powershell",
-      "tabTag": "#tab/cli-m365-ps",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "#tab/cli-m365-ps"
+      ],
       "authors": [
         {
           "name": "Adam Wójcik",
@@ -1401,7 +1717,2244 @@
           "pictureUrl": "https://avatars.githubusercontent.com/u/8781041?v=4"
         }
       ],
-      "tags": null
+      "tags": null,
+      "createDate": "2021-05-11",
+      "source": "script-samples"
+    },
+    {
+      "title": "Analyze User Profile Photos using Azure Computer Vision API",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/aad/analyze-user-profile-photos",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/aad/analyze-user-profile-photos/index.md",
+      "description": "This script uses Azure Cognitive Service API and Microsoft 365 CLI to analyze user profile pictures.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/aad/analyze-user-profile-photos/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Joseph Velliah",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/21008316?v=4"
+        }
+      ],
+      "tags": [
+        "ai",
+        "azure",
+        "users"
+      ],
+      "createDate": "2020-11-05",
+      "source": "cli"
+    },
+    {
+      "title": "Analyze users for known data breaches with have i been pwned",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/aad/analyze-users-haveibeenpwnd",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/aad/analyze-users-haveibeenpwnd/index.md",
+      "description": "Validate all your users against known breaches with the have i been pwned api.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/aad/analyze-users-haveibeenpwnd/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Albert-Jan Schot",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/15227781?v=4"
+        }
+      ],
+      "tags": [
+        "security",
+        "users"
+      ],
+      "createDate": "2022-02-07",
+      "source": "cli"
+    },
+    {
+      "title": "CLI - Delete all Microsoft 365 groups",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/aad/delete-m365-groups",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/aad/delete-m365-groups/index.md",
+      "description": "this script deletes the AAD groups you no longer need.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/aad/delete-m365-groups/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Aakash Bhardwaj",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/33526902?v=4"
+        },
+        {
+          "name": "Laura Kokkarinen",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/41330990?v=4"
+        }
+      ],
+      "tags": [
+        "cleanup",
+        "groups"
+      ],
+      "createDate": "2020-03-15",
+      "source": "cli"
+    },
+    {
+      "title": "CLI - Delete all Microsoft 365 groups and SharePoint sites",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/aad/delete-m365-groups-and-sharepoint-sites",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/aad/delete-m365-groups-and-sharepoint-sites/index.md",
+      "description": "delete all Microsoft 365 Groups and SharePoint Online site.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/aad/delete-m365-groups-and-sharepoint-sites/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Patrick Lamber",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/18241305?v=4"
+        }
+      ],
+      "tags": [
+        "cleanup",
+        "groups",
+        "sites"
+      ],
+      "createDate": "2021-03-15",
+      "source": "cli"
+    },
+    {
+      "title": "Scan for Microsoft 365 Groups created with user's first or last name",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/aad/flag-groups-with-user-names",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/aad/flag-groups-with-user-names/index.md",
+      "description": "This sample script scans the Microsoft 365 groups that may contain user’s first or last name as the group mail.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/aad/flag-groups-with-user-names/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Joseph Velliah",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/21008316?v=4"
+        }
+      ],
+      "tags": [
+        "users",
+        "groups",
+        "reports"
+      ],
+      "createDate": "2020-03-28",
+      "source": "cli"
+    },
+    {
+      "title": "Bulk add/remove users to Microsoft Teams and Microsoft 365 Groups",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/aad/manage-group-users",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/aad/manage-group-users/index.md",
+      "description": "Sample script to add/remove bulk users to/from Microsoft Teams team or Microsoft 365 groupl.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/aad/manage-group-users/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Joseph Velliah",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/21008316?v=4"
+        }
+      ],
+      "tags": [
+        "users",
+        "groups",
+        "security",
+        "teams"
+      ],
+      "createDate": "2020-05-09",
+      "source": "cli"
+    },
+    {
+      "title": "CLI - Replace a user's membership in selected Microsoft 365 Groups or Teams",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/aad/replace-membership-of-selected-groups",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/aad/replace-membership-of-selected-groups/index.md",
+      "description": "This script can be used to replace the membership of a user for a selected list of Groups.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/aad/replace-membership-of-selected-groups/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Patrick Lamber",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/18241305?v=4"
+        }
+      ],
+      "tags": [
+        "users",
+        "groups",
+        "security",
+        "teams",
+        "cleanup"
+      ],
+      "createDate": "2021-05-04",
+      "source": "cli"
+    },
+    {
+      "title": "CLI - Replace an owner in a Microsoft 365 Group or Microsoft Team",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/aad/replace-owner-with-a-different-one",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/aad/replace-owner-with-a-different-one/index.md",
+      "description": "Find all the Microsoft 365 Groups that a user is an Owner of and replace them with someone else.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/aad/replace-owner-with-a-different-one/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Patrick Lamber",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/18241305?v=4"
+        }
+      ],
+      "tags": [
+        "users",
+        "groups",
+        "security",
+        "teams"
+      ],
+      "createDate": "2021-04-28",
+      "source": "cli"
+    },
+    {
+      "title": "Cancel all running flow runs for a flow in an environment",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/flow/cancel-all-running-flow-runs",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/flow/cancel-all-running-flow-runs/index.md",
+      "description": "This script will cancel all running flow runs.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/flow/cancel-all-running-flow-runs/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Mohamed Ashiq Faleel",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/13963852?v=4"
+        }
+      ],
+      "tags": [
+        "cleanup",
+        "flows"
+      ],
+      "createDate": "2021-06-04",
+      "source": "cli"
+    },
+    {
+      "title": "CLI - Export all flows in environment",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/flow/export-all-flows-in-environment",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/flow/export-all-flows-in-environment/index.md",
+      "description": "This script will get all flows in your default environment and export them.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/flow/export-all-flows-in-environment/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Garry Trinder",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/11563347?v=4"
+        }
+      ],
+      "tags": [
+        "migration",
+        "flows"
+      ],
+      "createDate": "2021-06-16",
+      "source": "cli"
+    },
+    {
+      "title": "Export a single flow to a Logic App",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/flow/export-flow-logicapp",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/flow/export-flow-logicapp/index.md",
+      "description": "This script will export the Power Automate flow.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/flow/export-flow-logicapp/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Albert-Jan Schot",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/15227781?v=4"
+        }
+      ],
+      "tags": [
+        "migration",
+        "flows",
+        "azure"
+      ],
+      "createDate": "2021-02-07",
+      "source": "cli"
+    },
+    {
+      "title": "CLI - Flow runs day summary report",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/flow/flow-runs-day-summary",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/flow/flow-runs-day-summary/index.md",
+      "description": "This script creates a report of all flow runs from current day.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/flow/flow-runs-day-summary/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Adam Wójcik",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/58668583?v=4"
+        }
+      ],
+      "tags": [
+        "adaptivecards",
+        "flows",
+        "reports"
+      ],
+      "createDate": "2021-10-16",
+      "source": "cli"
+    },
+    {
+      "title": "Inventory Flows By Creator",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/flow/inventory-flows-by-author",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/flow/inventory-flows-by-author/index.md",
+      "description": "This script retrieves Flows from the Default Environment and maps creator information from Azure AD to list Flows by owner.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/flow/inventory-flows-by-author/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Pete Skelly",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/5527235?v=4"
+        }
+      ],
+      "tags": [
+        "users",
+        "flows",
+        "reports"
+      ],
+      "createDate": "2020-05-05",
+      "source": "cli"
+    },
+    {
+      "title": "Resubmit all failed flow runs for a flow in an environment",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/flow/resubmit-all-failed-flow-runs",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/flow/resubmit-all-failed-flow-runs/index.md",
+      "description": "This script will resubmit all failed flow runs.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/flow/resubmit-all-failed-flow-runs/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Mohamed Ashiq Faleel",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/13963852?v=4"
+        }
+      ],
+      "tags": [
+        "flows"
+      ],
+      "createDate": "2021-06-04",
+      "source": "cli"
+    },
+    {
+      "title": "Search flows for connections",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/flow/search-flows-for-connection",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/flow/search-flows-for-connection/index.md",
+      "description": "This sample allows you to get a report of all flows that are connected to a specific site or list.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/flow/search-flows-for-connection/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Albert-Jan Schot",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/15227781?v=4"
+        }
+      ],
+      "tags": [
+        "flows",
+        "reports"
+      ],
+      "createDate": "2021-05-23",
+      "source": "cli"
+    },
+    {
+      "title": "Authenticate with and call the Microsoft Graph",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/graph/call-graph",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/graph/call-graph/index.md",
+      "description": "This script shows different ways to call Graph API.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/graph/call-graph/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Garry Trinder",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/11563347?v=4"
+        }
+      ],
+      "tags": [
+        "graph"
+      ],
+      "createDate": "2020-05-02",
+      "source": "cli"
+    },
+    {
+      "title": "Add multiple tasks in Planner",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/planner/add-multiple-tasks",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/planner/add-multiple-tasks/index.md",
+      "description": "This script will create multiple tasks to a Planner plan from the information provided in your `csv` file.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/planner/add-multiple-tasks/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Veronique Lengelle",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/25181757?v=4"
+        }
+      ],
+      "tags": [
+        "migration",
+        "tasks"
+      ],
+      "createDate": "2022-04-30",
+      "source": "cli"
+    },
+    {
+      "title": "List all Power Platform Environments and their Flows and Apps",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/powerplatform/list-environments-flows-apps",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/powerplatform/list-environments-flows-apps/index.md",
+      "description": "This script will retrieve all environments as an Administrator and loop through all Flows and Apps to provide you with a report indicating how much Power Platform components are in use in the tenant.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/powerplatform/list-environments-flows-apps/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Albert-Jan Schot",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/15227781?v=4"
+        }
+      ],
+      "tags": [
+        "apps",
+        "flows",
+        "reports"
+      ],
+      "createDate": "2022-09-10",
+      "source": "cli"
+    },
+    {
+      "title": "CLI - Add App Catalog to SharePoint site",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/add-app-catalog",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/add-app-catalog/index.md",
+      "description": "Script will create an app catalog for that site.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/add-app-catalog/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "David Ramalho",
+          "pictureUrl": ""
+        }
+      ],
+      "tags": [
+        "provisioning",
+        "sites"
+      ],
+      "createDate": "2020-03-28",
+      "source": "cli"
+    },
+    {
+      "title": "Add custom client-side web part to modern page",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/add-custom-clientside-webpart-to-modern-page",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/add-custom-clientside-webpart-to-modern-page/index.md",
+      "description": "This sample helps you add your web part to the page.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/add-custom-clientside-webpart-to-modern-page/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Yannick Plenevaux",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/8345556?v=4"
+        }
+      ],
+      "tags": [
+        "provisioning",
+        "migration",
+        "pages"
+      ],
+      "createDate": "2020-05-20",
+      "source": "cli"
+    },
+    {
+      "title": "CLI - Add multiple folders in libraries using a csv file",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/add-multiple-folders-in-libraries-using-csv-file",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/add-multiple-folders-in-libraries-using-csv-file/index.md",
+      "description": "Adds multiple folders in libraries using a csv file.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/add-multiple-folders-in-libraries-using-csv-file/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Veronique Lengelle",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/25181757?v=4"
+        }
+      ],
+      "tags": [
+        "provisioning",
+        "files",
+        "libraries"
+      ],
+      "createDate": "2021-05-10",
+      "source": "cli"
+    },
+    {
+      "title": "Add multiple lists in multiple sites",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/add-multiple-lists-in-multiple-sites",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/add-multiple-lists-in-multiple-sites/index.md",
+      "description": "Adds multiple lists in multiple sites.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/add-multiple-lists-in-multiple-sites/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Sudharsan Kesavanarayanan",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/10280385?v=4"
+        }
+      ],
+      "tags": [
+        "provisioning",
+        "libraries"
+      ],
+      "createDate": "2021-07-05",
+      "source": "cli"
+    },
+    {
+      "title": "Add a Site Collection Admin using a csv file",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/add-site-collection-admin-using-csv-file",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/add-site-collection-admin-using-csv-file/index.md",
+      "description": "Adds a Site Collection Admin using a csv file.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/add-site-collection-admin-using-csv-file/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Veronique Lengelle",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/25181757?v=4"
+        }
+      ],
+      "tags": [
+        "users",
+        "security"
+      ],
+      "createDate": "2021-04-28",
+      "source": "cli"
+    },
+    {
+      "title": "Add users to the Associated SharePoint Groups of a site from a CSV File",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/add-users-associatedspgroup-site-csv-file",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/add-users-associatedspgroup-site-csv-file/index.md",
+      "description": "Script which adds multiple users to associated SharePoint groups.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/add-users-associatedspgroup-site-csv-file/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Arjun Menon",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/10369964?v=4"
+        }
+      ],
+      "tags": [
+        "users",
+        "groups",
+        "security"
+      ],
+      "createDate": "2021-10-16",
+      "source": "cli"
+    },
+    {
+      "title": "Change group membership of all SharePoint Online sites",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/change-owner-group-membership",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/change-owner-group-membership/index.md",
+      "description": "Script which downgrades the permission to the default member group.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/change-owner-group-membership/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Arjun Menon",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/10369964?v=4"
+        }
+      ],
+      "tags": [
+        "users",
+        "groups",
+        "security"
+      ],
+      "createDate": "2022-03-19",
+      "source": "cli"
+    },
+    {
+      "title": "Copy files to another SharePoint Library in another site",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/copy-files-to-another-library",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/copy-files-to-another-library/index.md",
+      "description": "This script shows how you can use the CLI to copy all files and folders from source library to a different library.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/copy-files-to-another-library/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Garry Trinder",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/11563347?v=4"
+        },
+        {
+          "name": "Adam Wójcik",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/58668583?v=4"
+        }
+      ],
+      "tags": [
+        "files",
+        "libraries",
+        "migration"
+      ],
+      "createDate": "2021-04-20",
+      "source": "cli"
+    },
+    {
+      "title": "Copy list items between SharePoint lists",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/copy-listitems-sharepointlist",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/copy-listitems-sharepointlist/index.md",
+      "description": "This script helps you to copy list items from one list to another list.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/copy-listitems-sharepointlist/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Sekar Thangavel",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/2954523?v=4"
+        }
+      ],
+      "tags": [
+        "lists",
+        "listitems",
+        "migration"
+      ],
+      "createDate": "2021-12-15",
+      "source": "cli"
+    },
+    {
+      "title": "Delete all (non-group connected) modern SharePoint sites",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/delete-non-group-connected-modern-sites",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/delete-non-group-connected-modern-sites/index.md",
+      "description": "The script handles the remaining modern sites: communication sites and groupless team sites.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/delete-non-group-connected-modern-sites/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Siddharth Vaghasia",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/9557557?v=4"
+        },
+        {
+          "name": "Laura Kokkarinen",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/41330990?v=4"
+        }
+      ],
+      "tags": [
+        "cleanup",
+        "sites"
+      ],
+      "createDate": "2020-06-25",
+      "source": "cli"
+    },
+    {
+      "title": "Detecting PII exists in SharePoint List using AWS Comprehend",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/detecting-pii-exists-in-sharepointlist-column",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/detecting-pii-exists-in-sharepointlist-column/index.md",
+      "description": "The script uses Amazon Comprehend to detect PII entities from a specific SharePoint List column record the results in another list and CSV report.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/detecting-pii-exists-in-sharepointlist-column/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Joseph Velliah",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/21008316?v=4"
+        }
+      ],
+      "tags": [
+        "compliance"
+      ],
+      "createDate": "2022-02-12",
+      "source": "cli"
+    },
+    {
+      "title": "Disable specified Tenant-wide Extension",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/disable-tenant-wide-extension",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/disable-tenant-wide-extension/index.md",
+      "description": "Script helps to disable the specified tenant wide extension based on the id parameter.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/disable-tenant-wide-extension/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Shantha Kumar T",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/34408892?v=4"
+        }
+      ],
+      "tags": [
+        "customizations",
+        "provisioning"
+      ],
+      "createDate": "2020-05-20",
+      "source": "cli"
+    },
+    {
+      "title": "CLI - Empty the tenant recycle bin",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/empty-tenant-recyclebin",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/empty-tenant-recyclebin/index.md",
+      "description": "Script deletes modern SharePoint sites from recycle bin.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/empty-tenant-recyclebin/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Michaël Maillot (onepoint)",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/44271458?v=4"
+        },
+        {
+          "name": "Laura Kokkarinen",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/41330990?v=4"
+        }
+      ],
+      "tags": [
+        "cleanup"
+      ],
+      "createDate": "2021-06-13",
+      "source": "cli"
+    },
+    {
+      "title": "Ensure the Site Assets Library is created",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/ensure-siteassets-library",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/ensure-siteassets-library/index.md",
+      "description": "Ensure that the Site Assets library is created.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/ensure-siteassets-library/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Phil Harding",
+          "pictureUrl": ""
+        }
+      ],
+      "tags": [
+        "provisioning",
+        "lists"
+      ],
+      "createDate": "2020-04-12",
+      "source": "cli"
+    },
+    {
+      "title": "Export Configurations of Tenant Wide Extensions",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/export-configs-tenant-wide-extensions",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/export-configs-tenant-wide-extensions/index.md",
+      "description": "This script retrieves Tenant Wide Extension configurations from the App Catalog and exports the same to CSV file.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/export-configs-tenant-wide-extensions/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Joseph Velliah",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/21008316?v=4"
+        }
+      ],
+      "tags": [
+        "customizations",
+        "reports"
+      ],
+      "createDate": "2020-08-21",
+      "source": "cli"
+    },
+    {
+      "title": "Grant API permissions to SharePoint Azure AD Application",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/grant-api-permissions-aad",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/grant-api-permissions-aad/index.md",
+      "description": "Grants API permissions to SharePoint Azure AD Application.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/grant-api-permissions-aad/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Michaël Maillot (onepoint)",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/44271458?v=4"
+        }
+      ],
+      "tags": [
+        "security"
+      ],
+      "createDate": "2021-03-19",
+      "source": "cli"
+    },
+    {
+      "title": "CLI - Hide SharePoint list from Site Contents",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/hide-list-from-site-contents",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/hide-list-from-site-contents/index.md",
+      "description": "hides the SharePoint list from the UI.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/hide-list-from-site-contents/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "David Ramalho",
+          "pictureUrl": ""
+        }
+      ],
+      "tags": [
+        "lists"
+      ],
+      "createDate": "2020-03-28",
+      "source": "cli"
+    },
+    {
+      "title": "Insert pictures in a SharePoint Document Library into a Word document",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/insert-sp-library-pictures-into-word",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/insert-sp-library-pictures-into-word/index.md",
+      "description": "Script shows how to download and insert many pictures.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/insert-sp-library-pictures-into-word/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Joseph Velliah",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/21008316?v=4"
+        }
+      ],
+      "tags": [
+        "libraries",
+        "files"
+      ],
+      "createDate": "2020-06-20",
+      "source": "cli"
+    },
+    {
+      "title": "List all application customizers in a tenant",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/list-all-application-customizers",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-all-application-customizers/index.md",
+      "description": "List all the application customizers in a tenant.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-all-application-customizers/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Rabia Williams",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/20379311?v=4"
+        }
+      ],
+      "tags": [
+        "customizations",
+        "reports"
+      ],
+      "createDate": "2021-06-17",
+      "source": "cli"
+    },
+    {
+      "title": "List all checked out files in SharePoint",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/list-all-checked-out-files",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-all-checked-out-files/index.md",
+      "description": "This script will retrieve all the checked out files in a particular site.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-all-checked-out-files/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Veronique Lengelle",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/25181757?v=4"
+        }
+      ],
+      "tags": [
+        "files",
+        "reports"
+      ],
+      "createDate": "2022-02-19",
+      "source": "cli"
+    },
+    {
+      "title": "List all documents with a specific name within a SharePoint site",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/list-all-files-specific-name",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-all-files-specific-name/index.md",
+      "description": "This script will retrieve all the files in a site that have a specific word.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-all-files-specific-name/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Albert-Jan Schot",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/15227781?v=4"
+        },
+        {
+          "name": "Veronique Lengelle",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/25181757?v=4"
+        }
+      ],
+      "tags": [
+        "files",
+        "reports"
+      ],
+      "createDate": "2022-02-01",
+      "source": "cli"
+    },
+    {
+      "title": "List all files with missing required metadata",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/list-all-files-with-missing-required-metadata",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-all-files-with-missing-required-metadata/index.md",
+      "description": "List all files with missing required metadata.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-all-files-with-missing-required-metadata/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Nico De Cleyre",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/35696168?v=4"
+        }
+      ],
+      "tags": [
+        "files",
+        "reports"
+      ],
+      "createDate": "2022-12-31",
+      "source": "cli"
+    },
+    {
+      "title": "List all items with unique permissions",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/list-all-items-with-unique-permissions",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-all-items-with-unique-permissions/index.md",
+      "description": "List all items for a specific SharePoint list on a site.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-all-items-with-unique-permissions/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Veronique Lengelle",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/25181757?v=4"
+        }
+      ],
+      "tags": [
+        "listitems",
+        "security"
+      ],
+      "createDate": "2022-02-09",
+      "source": "cli"
+    },
+    {
+      "title": "Lists number of files in all lists and folders for the given site",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/list-all-list-folders-itemcount",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-all-list-folders-itemcount/index.md",
+      "description": "List all Lists, the folders and sub folders in a given site, and output the item count.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-all-list-folders-itemcount/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Albert-Jan Schot",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/15227781?v=4"
+        }
+      ],
+      "tags": [
+        "files",
+        "libraries",
+        "reports"
+      ],
+      "createDate": "2021-06-22",
+      "source": "cli"
+    },
+    {
+      "title": "List Attachment Names From SharePoint Lists For A Site",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/list-attachment-names-from-spo-lists",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-attachment-names-from-spo-lists/index.md",
+      "description": "Lists Attachment Names From SharePoint Lists For A Site.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-attachment-names-from-spo-lists/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Veronique Lengelle",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/25181757?v=4"
+        }
+      ],
+      "tags": [
+        "files",
+        "lists",
+        "reports"
+      ],
+      "createDate": "2022-07-29",
+      "source": "cli"
+    },
+    {
+      "title": "List all external users in site groups across all site collections",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/list-externalusers-in-sitegroups",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-externalusers-in-sitegroups/index.md",
+      "description": "This script shows how you can check if external users are added to site groups.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-externalusers-in-sitegroups/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Martin Lingstuyl",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/5267487?v=4"
+        }
+      ],
+      "tags": [
+        "guests",
+        "groups",
+        "reports",
+        "sites",
+        "users"
+      ],
+      "createDate": "2022-07-25",
+      "source": "cli"
+    },
+    {
+      "title": "List all failed site design for all sites",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/list-failed-sitedesigns",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-failed-sitedesigns/index.md",
+      "description": "Script iterates through all site collections and lists all site design runs with errors.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-failed-sitedesigns/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Albert-Jan Schot",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/15227781?v=4"
+        }
+      ],
+      "tags": [
+        "reports"
+      ],
+      "createDate": "2021-07-05",
+      "source": "cli"
+    },
+    {
+      "title": "List all large files within a SharePoint Site",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/list-large-files-within-a-site",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-large-files-within-a-site/index.md",
+      "description": "Script will help you find every files in a specific SharePoint Online site that are over a certain size.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-large-files-within-a-site/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Veronique Lengelle",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/25181757?v=4"
+        }
+      ],
+      "tags": [
+        "files",
+        "reports"
+      ],
+      "createDate": "2022-06-28",
+      "source": "cli"
+    },
+    {
+      "title": "Lists active SharePoint site collection application catalogs",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/list-site-app-catalogs",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-site-app-catalogs/index.md",
+      "description": "Script will find all installed site collection application catalogs within a tenant.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-site-app-catalogs/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Velin Georgiev",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/1049476?v=4"
+        }
+      ],
+      "tags": [
+        "reports"
+      ],
+      "createDate": "2019-11-16",
+      "source": "cli"
+    },
+    {
+      "title": "List site collections and their lists",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/list-site-collection-lists",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-site-collection-lists/index.md",
+      "description": "Script helps you to list and export all site collection and their lists SharePoint Online sites.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-site-collection-lists/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Albert-Jan Schot",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/15227781?v=4"
+        }
+      ],
+      "tags": [
+        "reports",
+        "lists",
+        "sites"
+      ],
+      "createDate": "2021-03-12",
+      "source": "cli"
+    },
+    {
+      "title": "List site collection owners",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/list-site-collection-owners",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-site-collection-owners/index.md",
+      "description": "This script helps you to list and export all site collection owners in your SharePoint Online sites.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-site-collection-owners/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Patrick Lamber",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/18241305?v=4"
+        }
+      ],
+      "tags": [
+        "reports",
+        "security",
+        "users"
+      ],
+      "createDate": "2021-02-27",
+      "source": "cli"
+    },
+    {
+      "title": "CLI - List all external users in all site collections",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/list-site-externalusers",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-site-externalusers/index.md",
+      "description": "This script helps you to list all external users in all SharePoint Online sites.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-site-externalusers/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Albert-Jan Schot",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/15227781?v=4"
+        }
+      ],
+      "tags": [
+        "guests",
+        "security",
+        "users"
+      ],
+      "createDate": "2021-03-15",
+      "source": "cli"
+    },
+    {
+      "title": "CLI - List all tenant-wide extensions",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/list-tenant-wide-extensions",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-tenant-wide-extensions/index.md",
+      "description": "This script lists all tenant-wide extensions deployed in the tenant.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/list-tenant-wide-extensions/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Shantha Kumar T",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/34408892?v=4"
+        }
+      ],
+      "tags": [
+        "customizations",
+        "reports"
+      ],
+      "createDate": "2020-04-12",
+      "source": "cli"
+    },
+    {
+      "title": "Monitor Site Collections Storage Usage",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/monitor-site-collection-storage-usage",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/monitor-site-collection-storage-usage/index.md",
+      "description": "This script allows you to monitor Site Collections Storage Usage.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/monitor-site-collection-storage-usage/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Veronique Lengelle",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/25181757?v=4"
+        }
+      ],
+      "tags": [
+        "sites",
+        "reports"
+      ],
+      "createDate": "2021-05-04",
+      "source": "cli"
+    },
+    {
+      "title": "How to perform operations if a command is not covered by the CLI for Microsoft 365",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/perform-operations-not-covered-by-cli-for-microsoft-365",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/perform-operations-not-covered-by-cli-for-microsoft-365/index.md",
+      "description": "This script shows how to perform operations if a command is not covered by the CLI for Microsoft 365.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/perform-operations-not-covered-by-cli-for-microsoft-365/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Joseph Velliah",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/21008316?v=4"
+        }
+      ],
+      "tags": [
+        "files",
+        "listitems"
+      ],
+      "createDate": "2021-10-24",
+      "source": "cli"
+    },
+    {
+      "title": "Planner migration to SharePoint list",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/planner-migrate-sharepoint-list",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/planner-migrate-sharepoint-list/index.md",
+      "description": "This script migrates an existing plan to a SharePoint Online List with this sample.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/planner-migrate-sharepoint-list/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Albert-Jan Schot",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/15227781?v=4"
+        }
+      ],
+      "tags": [
+        "lists",
+        "migration",
+        "tasks"
+      ],
+      "createDate": "2022-03-12",
+      "source": "cli"
+    },
+    {
+      "title": "Remove SharePoint API permissions",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/remove-api-permissions",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/remove-api-permissions/index.md",
+      "description": "This script helps you to quickly remove SharePoint API permissions.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/remove-api-permissions/assets/preview.png",
+      "type": [
+        "javascript"
+      ],
+      "tabTag": [
+        "```javascript"
+      ],
+      "authors": [
+        {
+          "name": "Waldek Mastykarz",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/11164679?v=4"
+        }
+      ],
+      "tags": [
+        "security"
+      ],
+      "createDate": "2021-06-17",
+      "source": "cli"
+    },
+    {
+      "title": "CLI - Delete custom color themes from SharePoint",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/remove-custom-themes",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/remove-custom-themes/index.md",
+      "description": "This script removes custom color themes from SharePoint.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/remove-custom-themes/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Laura Kokkarinen",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/41330990?v=4"
+        }
+      ],
+      "tags": [
+        "provisioning",
+        "cleanup"
+      ],
+      "createDate": "2019-10-13",
+      "source": "cli"
+    },
+    {
+      "title": "CLI - Remove orphaned redirect sites",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/remove-orphaned-redirect-sites",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/remove-orphaned-redirect-sites/index.md",
+      "description": "This script provides you with an overview of all orphaned redirect sites and allows you to quickly delete them.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/remove-orphaned-redirect-sites/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Albert-Jan Schot",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/15227781?v=4"
+        }
+      ],
+      "tags": [
+        "cleanup",
+        "sites"
+      ],
+      "createDate": "2020-09-06",
+      "source": "cli"
+    },
+    {
+      "title": "Remove pending SharePoint API permission requests",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/remove-pending-api-permission-requests",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/remove-pending-api-permission-requests/index.md",
+      "description": "This script helps you to quickly remove pending SharePoint API permission requests.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/remove-pending-api-permission-requests/assets/preview.png",
+      "type": [
+        "javascript"
+      ],
+      "tabTag": [
+        "```javascript"
+      ],
+      "authors": [
+        {
+          "name": "Smita Nachan",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/65232102?v=4"
+        },
+        {
+          "name": "Waldek Mastykarz",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/11164679?v=4"
+        }
+      ],
+      "tags": [
+        "cleanup",
+        "security"
+      ],
+      "createDate": "2021-06-17",
+      "source": "cli"
+    },
+    {
+      "title": "CLI - Delete custom SharePoint site designs",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/remove-site-designs",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/remove-site-designs/index.md",
+      "description": "This script helps you get rid of custom SharePoint site designs.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/remove-site-designs/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Laura Kokkarinen",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/41330990?v=4"
+        }
+      ],
+      "tags": [
+        "cleanup"
+      ],
+      "createDate": "2019-10-20",
+      "source": "cli"
+    },
+    {
+      "title": "CLI - Delete custom SharePoint site scripts",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/remove-site-scripts",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/remove-site-scripts/index.md",
+      "description": "This script helps you get rid of custom SharePoint site scripts.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/remove-site-scripts/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Laura Kokkarinen",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/41330990?v=4"
+        },
+        {
+          "name": "Siddharth Vaghasia",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/9557557?v=4"
+        }
+      ],
+      "tags": [
+        "cleanup"
+      ],
+      "createDate": "2020-03-15",
+      "source": "cli"
+    },
+    {
+      "title": "Remove a Site Collection Admin User from all Site Collections",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/remove-siteCollection-admin-user",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/remove-siteCollection-admin-user/index.md",
+      "description": "This script removes a Site Collection Admin User from all Site Collections.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/remove-siteCollection-admin-user/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Veronique Lengelle",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/25181757?v=4"
+        }
+      ],
+      "tags": [
+        "cleanup",
+        "security",
+        "sites",
+        "users"
+      ],
+      "createDate": "2021-04-23",
+      "source": "cli"
+    },
+    {
+      "title": "Replace site collection admin with another user",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/replace-site-collection-admin",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/replace-site-collection-admin/index.md",
+      "description": "The script removes a user from a site collection and adds a new one as site collection admin.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/replace-site-collection-admin/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Patrick Lamber",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/18241305?v=4"
+        }
+      ],
+      "tags": [
+        "security",
+        "users"
+      ],
+      "createDate": "2021-05-17",
+      "source": "cli"
+    },
+    {
+      "title": "CLI - Setup example site",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/setup-example-site",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/setup-example-site/index.md",
+      "description": "This script is a good starting point for a setup script to create site with some assets like columns, content types, lists, navigation etc.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/setup-example-site/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Adam Wójcik",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/58668583?v=4"
+        }
+      ],
+      "tags": [
+        "libraries",
+        "lists",
+        "provisioning",
+        "sites"
+      ],
+      "createDate": "2021-04-10",
+      "source": "cli"
+    },
+    {
+      "title": "Sync SharePoint Document Library Documents with Azure Storage Container",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/sync-splib-into-az-storage-container",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/sync-splib-into-az-storage-container/index.md",
+      "description": "This script shows how to download and sync documents in a SharePoint Document Library into an Azure Storage Container.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/sync-splib-into-az-storage-container/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Joseph Velliah",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/21008316?v=4"
+        }
+      ],
+      "tags": [
+        "azure",
+        "files",
+        "migration"
+      ],
+      "createDate": "2020-06-15",
+      "source": "cli"
+    },
+    {
+      "title": "Upload local files and folders to SharePoint Online",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/spo/upload-local-files-and-folder",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/upload-local-files-and-folder/index.md",
+      "description": "This script shows how you can use the CLI to upload files located on a local folder to a SharePoint Online library.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/spo/upload-local-files-and-folder/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Adam Wójcik",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/58668583?v=4"
+        },
+        {
+          "name": "Patrick Lamber",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/18241305?v=4"
+        }
+      ],
+      "tags": [
+        "files",
+        "migration"
+      ],
+      "createDate": "2021-04-13",
+      "source": "cli"
+    },
+    {
+      "title": "Bulk add members to Microsoft Teams team from CSV file",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/teams/add-bulk-users-teams",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/add-bulk-users-teams/index.md",
+      "description": "Adds bulk users from CSV file to MS Teams.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/add-bulk-users-teams/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Veronique Lengelle",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/25181757?v=4"
+        }
+      ],
+      "tags": [
+        "users",
+        "provisioning"
+      ],
+      "createDate": "2021-04-17",
+      "source": "cli"
+    },
+    {
+      "title": "Create a Microsoft Teams team and bulk add members from CSV file",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/teams/create-team-and-add-members-and-owners",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/create-team-and-add-members-and-owners/index.md",
+      "description": "This sample script shows you how to create a Team and add members and owners using a CSV.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/create-team-and-add-members-and-owners/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Patrick Lamber",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/18241305?v=4"
+        }
+      ],
+      "tags": [
+        "users",
+        "provisioning",
+        "teams"
+      ],
+      "createDate": "2021-04-10",
+      "source": "cli"
+    },
+    {
+      "title": "Create a Microsoft Team with channels from a Microsoft 365 Group",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/teams/create-team-from-group",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/create-team-from-group/index.md",
+      "description": "Creates a Microsoft 365 Group, associates a logo to it and some members.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/create-team-from-group/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Patrick Lamber",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/18241305?v=4"
+        }
+      ],
+      "tags": [
+        "groups",
+        "provisioning",
+        "teams"
+      ],
+      "createDate": "2021-03-10",
+      "source": "cli"
+    },
+    {
+      "title": "Deploy Microsoft Teams app from Azure DevOps",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/teams/deploy-teams-app",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/deploy-teams-app/index.md",
+      "description": "Installs or updates a Microsoft Teams app from an Azure DevOps pipeline.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/deploy-teams-app/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Garry Trinder",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/11563347?v=4"
+        }
+      ],
+      "tags": [
+        "apps",
+        "pipelines",
+        "provisioning"
+      ],
+      "createDate": "2020-05-02",
+      "source": "cli"
+    },
+    {
+      "title": "Export all channels in Microsoft Teams teams in the tenant",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/teams/export-all-channels-teams",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/export-all-channels-teams/index.md",
+      "description": "Export all the channels from Microsoft Team in a CSV.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/export-all-channels-teams/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Sudharsan Kesavanarayanan",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/10280385?v=4"
+        }
+      ],
+      "tags": [
+        "migration",
+        "teams"
+      ],
+      "createDate": "2021-11-02",
+      "source": "cli"
+    },
+    {
+      "title": "Export conversations from Microsoft Teams Channels",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/teams/export-teams-conversations",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/export-teams-conversations/index.md",
+      "description": "This script exports the conversations from Microsoft Teams Channels.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/export-teams-conversations/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Joseph Velliah",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/21008316?v=4"
+        }
+      ],
+      "tags": [
+        "migration",
+        "teams"
+      ],
+      "createDate": "2021-02-19",
+      "source": "cli"
+    },
+    {
+      "title": "Get all the Teams a specific user is part of",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/teams/get-all-teams-specific-user-is-part-of",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/get-all-teams-specific-user-is-part-of/index.md",
+      "description": "Gets all the Teams a specific user is part of.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/get-all-teams-specific-user-is-part-of/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Veronique Lengelle",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/25181757?v=4"
+        }
+      ],
+      "tags": [
+        "teams",
+        "reports",
+        "users"
+      ],
+      "createDate": "2021-09-14",
+      "source": "cli"
+    },
+    {
+      "title": "Govern orphaned Microsoft Teams",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/teams/govern-orphan-teams",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/govern-orphan-teams/index.md",
+      "description": "This script finds teams that no longer have an owner.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/govern-orphan-teams/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Garry Trinder",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/11563347?v=4"
+        }
+      ],
+      "tags": [
+        "reports",
+        "security",
+        "teams",
+        "users"
+      ],
+      "createDate": "2020-05-02",
+      "source": "cli"
+    },
+    {
+      "title": "Deploy Microsoft Teams personal app and add it to users",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/teams/install-personal-app",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/install-personal-app/index.md",
+      "description": "Installs or updates a Microsoft Teams app.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/install-personal-app/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Sébastien Levert",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/7620955?v=4"
+        }
+      ],
+      "tags": [
+        "apps",
+        "provisioning",
+        "users"
+      ],
+      "createDate": "2020-10-18",
+      "source": "cli"
+    },
+    {
+      "title": "List all tabs in Microsoft Teams teams in the tenant",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/teams/list-all-tabs-teams",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/list-all-tabs-teams/index.md",
+      "description": "List all tabs in Microsoft Teams teams in the tenant and exports the results in a CSV.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/list-all-tabs-teams/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Patrick Lamber",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/18241305?v=4"
+        }
+      ],
+      "tags": [
+        "reports",
+        "teams"
+      ],
+      "createDate": "2021-02-27",
+      "source": "cli"
+    },
+    {
+      "title": "List all team members in Microsoft Teams teams in the tenant",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/teams/list-all-teammembers-teams",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/list-all-teammembers-teams/index.md",
+      "description": "List all team members in Microsoft Teams teams in the tenant and exports the results in a CSV.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/list-all-teammembers-teams/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Sudharsan Kesavanarayanan",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/10280385?v=4"
+        }
+      ],
+      "tags": [
+        "users",
+        "reports",
+        "teams"
+      ],
+      "createDate": "2021-09-02",
+      "source": "cli"
+    },
+    {
+      "title": "List app usage in Microsoft Teams",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/teams/list-teams-app-usage",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/list-teams-app-usage/index.md",
+      "description": "Iterates through all the teams in your tenant and lists all apps in each team.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/list-teams-app-usage/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Arjun Menon",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/10369964?v=4"
+        }
+      ],
+      "tags": [
+        "apps",
+        "reports",
+        "teams"
+      ],
+      "createDate": "2020-07-17",
+      "source": "cli"
+    },
+    {
+      "title": "List Microsoft Teams teams, channels, and tabs in the tenant",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/teams/list-teams-channels-tabs-for-tenant",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/list-teams-channels-tabs-for-tenant/index.md",
+      "description": "This script allows you to list all teams, channels and tabs.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/list-teams-channels-tabs-for-tenant/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Veronique Lengelle",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/25181757?v=4"
+        }
+      ],
+      "tags": [
+        "reports",
+        "teams"
+      ],
+      "createDate": "2021-10-16",
+      "source": "cli"
+    },
+    {
+      "title": "CLI - List all Microsoft Teams team's Owners and Members",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/teams/list-teams-owners-and-members",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/list-teams-owners-and-members/index.md",
+      "description": "This script allows you to list all Teams team's owners and members and export them into a CSV file.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/list-teams-owners-and-members/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Patrick Lamber",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/18241305?v=4"
+        }
+      ],
+      "tags": [
+        "teams"
+      ],
+      "createDate": "2021-03-23",
+      "source": "cli"
+    },
+    {
+      "title": "Recognize most active users for a specific Team",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/teams/recognize-most-active-users-specific-team",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/recognize-most-active-users-specific-team/index.md",
+      "description": "Retrieves all activities for a specific Microsoft Teams Team and shares the top 3 contributors.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/recognize-most-active-users-specific-team/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Albert-Jan Schot",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/15227781?v=4"
+        }
+      ],
+      "tags": [
+        "adoption",
+        "users"
+      ],
+      "createDate": "2021-08-27",
+      "source": "cli"
+    },
+    {
+      "title": "Removes Microsoft Teams personal app from users and Microsoft Teams app catalog",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/teams/remove-personal-app",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/remove-personal-app/index.md",
+      "description": "Uninstalls an app from the specified users and / or unpublish it from the Microsoft Teams app catalog based on the App Id.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/remove-personal-app/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Sébastien Levert",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/7620955?v=4"
+        }
+      ],
+      "tags": [
+        "apps",
+        "cleanup"
+      ],
+      "createDate": "2020-10-27",
+      "source": "cli"
+    },
+    {
+      "title": "Remove Wiki tab in a Microsoft Teams channel",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/teams/remove-wikitab-teams",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/remove-wikitab-teams/index.md",
+      "description": "Removes the wiki tab of a Microsoft Teams Team's channel.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/remove-wikitab-teams/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Rabia Williams",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/20379311?v=4"
+        }
+      ],
+      "tags": [
+        "cleanup",
+        "teams"
+      ],
+      "createDate": "2020-08-23",
+      "source": "cli"
+    },
+    {
+      "title": "Share social champions to Teams",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/teams/share-socialchampions",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/share-socialchampions/index.md",
+      "description": "Retrieves activities for SharePoint Online, Teams and Yammer and shares the top 3 contributors for each category as an adaptive card to the specified webhook url.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/teams/share-socialchampions/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Albert-Jan Schot",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/15227781?v=4"
+        }
+      ],
+      "tags": [
+        "users",
+        "adoption"
+      ],
+      "createDate": "2021-08-12",
+      "source": "cli"
+    },
+    {
+      "title": "Monitor and notify Microsoft 365 health status",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/tenant/tenant-monitor-notify-healthstatus",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/tenant/tenant-monitor-notify-healthstatus/index.md",
+      "description": "This is a script which monitors the health status of your Microsoft 365 tenant and notifies if something is not normal.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/tenant/tenant-monitor-notify-healthstatus/assets/preview.png",
+      "type": [
+        "powershell"
+      ],
+      "tabTag": [
+        "```powershell"
+      ],
+      "authors": [
+        {
+          "name": "Arjun Menon",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/10369964?v=4"
+        }
+      ],
+      "tags": [
+        "reports"
+      ],
+      "createDate": "2021-03-25",
+      "source": "cli"
+    },
+    {
+      "title": "Cleanup completed Microsoft To Do tasks",
+      "url": "https://pnp.github.io/cli-microsoft365/sample-scripts/todo/cleanup-completed-todos",
+      "rawUrl": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/todo/cleanup-completed-todos/index.md",
+      "description": "This script iterates across all of the task lists and removes the tasks that have been marked as complete.",
+      "image": "https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/todo/cleanup-completed-todos/assets/preview.png",
+      "type": [
+        "powershell",
+        "bash"
+      ],
+      "tabTag": [
+        "```powershell",
+        "```bash"
+      ],
+      "authors": [
+        {
+          "name": "Garry Trinder",
+          "pictureUrl": "https://avatars.githubusercontent.com/u/11563347?v=4"
+        }
+      ],
+      "tags": [
+        "cleanup",
+        "tasks"
+      ],
+      "createDate": "2021-04-09",
+      "source": "cli"
     }
   ]
 }

--- a/models/ISample.ts
+++ b/models/ISample.ts
@@ -7,7 +7,8 @@ export interface ISample {
     rawUrl: string;
     description: string;
     image: string;
-    type: string;
+    type: string[];
     tags: string[];
     authors: IAuthor[];
+    createDate: string;
 }

--- a/scripts/createScriptSampleDefenition.ps1
+++ b/scripts/createScriptSampleDefenition.ps1
@@ -1,11 +1,17 @@
-param ($scriptSampleFolderPath)
+param ($scriptSampleFolderPath, $cliScriptSampleFolderPath)
 
 if ($null -eq $scriptSampleFolderPath -or $scriptSampleFolderPath -eq "") {
     write-host "Please pass path to script samples from pnp/script-sample repo"
     exit
 }
 
+if ($null -eq $cliScriptSampleFolderPath -or $cliScriptSampleFolderPath -eq "") {
+    write-host "Please pass path to script samples folder from pnp/cli-microsoft365 repo"
+    exit
+}
+
 $allSamples = Get-ChildItem -Path "$scriptSampleFolderPath\scripts\**\sample.json" -Recurse -Force
+$allCLiSamples = Get-ChildItem -Path "$cliScriptSampleFolderPath\**\sample.json" -Recurse -Force
 
 [hashtable]$sampleModel = @{}
 $samples = @()
@@ -23,21 +29,21 @@ foreach ($sample in $allSamples) {
 
     $readme = $sample.FullName.Replace('assets\sample.json', 'README.md')
     $readmeContent = Get-Content -Path $readme -Raw
-    $type = ''
-    $tabTag = ''
+    $type = @()
+    $tabTag = @()
     if ($readmeContent.Contains("#tab/cli-m365-ps")) {
-        $type = 'powershell'
-        $tabTag = '#tab/cli-m365-ps'
+        $type += 'powershell'
+        $tabTag += '#tab/cli-m365-ps'
     }
     
     if ($readmeContent.Contains("#tab/cli-m365-bash")) {
-        $type = 'bash'
-        $tabTag = '#tab/cli-m365-bash'
+        $type += 'bash'
+        $tabTag += '#tab/cli-m365-bash'
     }
 
     if ($readmeContent.Contains("#tab/m365cli-bash")) {
-        $type = 'bash'
-        $tabTag = '#tab/m365cli-bash'
+        $type += 'bash'
+        $tabTag += '#tab/m365cli-bash'
     }
     
     $rawUrl = $sampleJson.url
@@ -61,7 +67,60 @@ foreach ($sample in $allSamples) {
         type        = $type;
         tabTag      = $tabTag;
         authors     = $sampleAuthors;
-        tags        = $sampleJson.tags
+        tags        = $sampleJson.tags;
+        createDate  = $sampleJson.creationDateTime;
+        source      = 'script-samples'
+    }
+}
+
+foreach ($sample in $allCLiSamples) {
+    $sampleContent = Get-Content -Path $sample.FullName -Raw
+    $sampleJson = ConvertFrom-Json -InputObject $sampleContent
+    
+    $index = $sample.FullName.Replace('assets\sample.json', 'index.md')
+    $indexContent = Get-Content -Path $index -Raw
+    $type = @()
+    $tabTag = @()
+
+    if ($indexContent.Contains('```powershell')) {
+        $type += 'powershell'
+        $tabTag += '```powershell'
+    }
+    
+    if ($indexContent.Contains('```bash')) {
+        $type += 'bash'
+        $tabTag += '```bash'
+    }
+    
+    if ($indexContent.Contains('```javascript')) {
+        $type += 'javascript'
+        $tabTag += '```javascript'
+    }
+
+    $rawUrl = $sampleJson.url
+    $rawUrl = $rawUrl.Replace('https://pnp.github.io/cli-microsoft365/sample-scripts/', 'https://raw.githubusercontent.com/pnp/cli-microsoft365/main/docs/docs/sample-scripts/')
+    $rawUrl = "$rawUrl/index.md"
+    
+    $sampleAuthors = @()
+    foreach($author in $sampleJson.authors) {
+        $sampleAuthors += [pscustomobject]@{ 
+            name        = $author.name;
+            pictureUrl  = $author.pictureUrl;
+        }
+    }
+
+    $samples += [pscustomobject]@{
+        title       = $sampleJson.title; 
+        url         = $sampleJson.url; 
+        rawUrl      = $rawUrl; 
+        description = $sampleJson.shortDescription; 
+        image       = $sampleJson.thumbnails[0].url; 
+        type        = $type;
+        tabTag      = $tabTag;
+        authors     = $sampleAuthors;
+        tags        = $sampleJson.tags;
+        createDate  = $sampleJson.creationDateTime;
+        source      = 'cli'
     }
 }
 

--- a/webview-ui/samplesView/components/appComponent/App.tsx
+++ b/webview-ui/samplesView/components/appComponent/App.tsx
@@ -24,8 +24,10 @@ export default class App extends React.Component<IAppProps, IAppState> {
   public componentDidMount(): void {
     const { searchQuery } = this.props;
 
+    const samplesList = samples.samples as ISample[];
+
     this.setState({
-      samples: samples.samples as ISample[],
+      samples: samplesList.sort((a,b) => new Date(b.createDate).getTime() - new Date(a.createDate).getTime()),
       loading: false,
       searchQueryInput: searchQuery ?? ''
     });

--- a/webview-ui/samplesView/components/cardComponent/Card.tsx
+++ b/webview-ui/samplesView/components/cardComponent/Card.tsx
@@ -25,7 +25,7 @@ export default class Card extends React.Component<ICardProps, ICardState> {
         <div className='card-body'>
           <h3>{sample.title.length > sampleTitleLimit ? `${sample.title.substring(0, sampleTitleLimit)}...` : sample.title}</h3>
           <div className='card-tags'>
-            <VSCodeTag>{sample.type}</VSCodeTag>
+            {sample.type.map((type: string, index: number) => <VSCodeTag key={index}>{type}</VSCodeTag>)}
           </div>
           <p>{sample.description.length > sampleDescriptionLimit ? `${sample.description.substring(0, sampleDescriptionLimit)}...` : sample.description}</p>
           <div className='card-footer'>
@@ -34,13 +34,16 @@ export default class Card extends React.Component<ICardProps, ICardState> {
                 Repo
                 <span slot="start" className="codicon codicon-github-inverted"></span>
               </VSCodeButton>
-              {sample.type !== '' ?
-                <VSCodeButton appearance="secondary" onClick={() => this._handleCreateScriptButtonClick(sample.title)}>
-                  Script
-                  {sample.type === 'powershell' ? <span slot="start" className="codicon codicon-terminal-powershell"></span> : ''}
-                  {sample.type === 'bash' ? <span slot="start" className="codicon codicon-terminal-bash"></span> : ''}
-                </VSCodeButton>
-                : ''}
+              {sample.type.map((type: string, index: number) => {
+                return (
+                  <VSCodeButton key={index} appearance="secondary" onClick={() => this._handleCreateScriptButtonClick(sample.title, type)}>
+                    Script
+                    {type === 'powershell' ? <span slot="start" className="codicon codicon-terminal-powershell"></span> : ''}
+                    {type === 'bash' ? <span slot="start" className="codicon codicon-terminal-bash"></span> : ''}
+                    {type === 'javascript' ? <span slot="start" className="codicon codicon-terminal"></span> : ''}
+                  </VSCodeButton>
+                );
+              })}
             </div>
             <div className='card-footer-authors'>
               {sample.authors.map((author, index) => {
@@ -64,10 +67,11 @@ export default class Card extends React.Component<ICardProps, ICardState> {
     });
   }
 
-  private _handleCreateScriptButtonClick(title: string): void {
+  private _handleCreateScriptButtonClick(title: string, type: string): void {
     vscode.postMessage({
       command: 'createScriptFile',
       value: title,
+      type: type
     });
   }
 }


### PR DESCRIPTION
## 🎯 Aim

The aim is to add samples from CLI repo to the sample gallery and also give the possibility to have multiple scripts for the same sample in different tech

## 📷 Result

![image](https://user-images.githubusercontent.com/58668583/211222716-d2eb25ab-71ce-4910-8b14-055353a59232.png)

## ✅ What was done

- [X] extended PS script to sync samples from CLI repo as well (wiki update)
- [X] modified samples gallery web UI react app

## 🔗 Related issue

#51 